### PR TITLE
Poprawiona funkcja expansion

### DIFF
--- a/Optimization/src/main.cpp
+++ b/Optimization/src/main.cpp
@@ -71,7 +71,8 @@ void lab1()
 	double epsilon = 1e-2;
 	int Nmax = 10000;
 
-	double* result = expansion(lab1_fun, -100, 1, 1.2, Nmax);
+	//double* result = expansion(lab1_fun, -100, 1, 1.01, Nmax); //to wypluje minimum lokalne, to po lewej
+	double* result = expansion(lab1_fun, 50, 1, 1.01, Nmax); //to wypluje minimum globalne, to po prawej
 
 	cout << result[0] << ", " << result[1] << "\n";
 }

--- a/Optimization/src/opt_alg.cpp
+++ b/Optimization/src/opt_alg.cpp
@@ -45,6 +45,9 @@ double* expansion(matrix(*ff)(matrix, matrix, matrix), double x0, double d, doub
 		sx0.fit_fun(ff);
 		sx1.fit_fun(ff);
 
+		//cout << "f(" << m2d(sx0.x) << ") = " << m2d(sx0.y) << endl;
+		//cout << "f(" << m2d(sx1.x) << ") = " << m2d(sx1.y) << endl;
+
 		if (sx0.y == sx1.y)
 		{
 			p[0] = m2d(sx0.x);
@@ -68,18 +71,21 @@ double* expansion(matrix(*ff)(matrix, matrix, matrix), double x0, double d, doub
 		}
 		
 		solution sx2(x0 + d);
+		sx2.fit_fun(ff); //tego brakowalo, inaczej wychodzila wartosc sx2.y = -nan(ind)
 
 		do
 		{
 			if (sx0.f_calls > Nmax)
 				throw ("Przekroczono limit wywolan funkcji :)");
-
 			i++;
-			sx0 = sx1;
-			sx1 = sx2;
 
-			sx2 = m2d(sx0.x) + pow(alpha, i) * d;
-		} while (sx1.y > sx2.y);
+			sx0 = sx1;
+			sx1 = sx2; 
+
+			sx2.x = m2d(sx0.x) + pow(alpha, i) * d; 
+			sx2.fit_fun(ff);
+			//cout << m2d(sx1.y) << " > " << m2d(sx2.y) << " ? " << endl;
+		} while (m2d(sx1.y) > m2d(sx2.y)); //tu teraz porownuje przed m2d (przedtem brakowalo, tak jest bezpieczniej imo)
 
 		if (d > 0)
 		{


### PR DESCRIPTION
Nie zatrzymuje sie po jednej pętli, było to spowodowane wartościami -nan(ind) które wynikały ze złego syntaxu. Zkalibrowałem też wartości d i alpha aby granice wyszły bardziej precyzyjne, i dla punktu początkowego -100 otrzymujemy minimum lokalne, a dla 50 globalne.